### PR TITLE
Update live_url per Sage Integration Support

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -139,6 +139,10 @@ module ActiveMerchant #:nodoc:
           gsub(%r((<VerificationStr2>).+(</VerificationStr2>)), '\1[FILTERED]\2')
       end
 
+      def supports_network_tokenization?
+        true
+      end
+
       private
 
       def build_request(action, body)
@@ -157,7 +161,7 @@ module ActiveMerchant #:nodoc:
       def build_sale_or_authorization_request(money, credit_card_or_store_authorization, options)
         xml = Builder::XmlMarkup.new
 
-        add_amount(xml, money)
+        add_amount(xml, money, options)
 
         if credit_card_or_store_authorization.is_a? String
           add_credit_card_token(xml, credit_card_or_store_authorization)
@@ -168,6 +172,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(xml, options)
         add_invoice(xml, options)
         add_card_authentication_data(xml, options)
+        add_level_2_and_3(xml, options)
 
         xml.target!
       end
@@ -176,7 +181,7 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new
 
         add_identification(xml, identification)
-        add_amount(xml, money)
+        add_amount(xml, money, options)
         add_customer_data(xml, options)
         add_card_authentication_data(xml, options)
 
@@ -208,8 +213,10 @@ module ActiveMerchant #:nodoc:
         xml.tag! "Transaction_Tag", transaction_tag
       end
 
-      def add_amount(xml, money)
-        xml.tag! "DollarAmount", amount(money)
+      def add_amount(xml, money, options)
+        currency_code = options[:currency] || default_currency
+        xml.tag! 'DollarAmount', localized_amount(money, currency_code)
+        xml.tag! 'Currency', currency_code
       end
 
       def add_credit_card(xml, credit_card, options)
@@ -297,6 +304,11 @@ module ActiveMerchant #:nodoc:
         xml.tag! "Reference_3",  options[:description] if options[:description]
       end
 
+      def add_level_2_and_3(xml, options)
+        xml.tag!("Level2") { |x| x << options[:level_2] } if options[:level_2]
+        xml.tag!("Level3") { |x| x << options[:level_3] } if options[:level_3]
+      end
+
       def expdate(credit_card)
         "#{format(credit_card.month, :two_digits)}#{format(credit_card.year, :two_digits)}"
       end
@@ -339,7 +351,7 @@ module ActiveMerchant #:nodoc:
           [
             response[:authorization_num],
             response[:transaction_tag],
-            (response[:dollar_amount].to_f * 100).to_i
+            response[:dollar_amount].sub(".", "")
           ].join(";")
         else
           ""
@@ -363,7 +375,7 @@ module ActiveMerchant #:nodoc:
 
       def money_from_authorization(auth)
         _, _, amount = auth.split(/;/, 3)
-        amount.to_i # return the # of cents, no need to divide
+        amount.to_i
       end
 
       def message_from(response)
@@ -410,4 +422,3 @@ module ActiveMerchant #:nodoc:
     end
   end
 end
-

--- a/lib/active_merchant/billing/gateways/hps.rb
+++ b/lib/active_merchant/billing/gateways/hps.rb
@@ -157,8 +157,8 @@ module ActiveMerchant #:nodoc:
               xml.hps 'Ver1.0'.to_sym do
                 xml.hps :Header do
                   xml.hps :SecretAPIKey, @options[:secret_api_key]
-                  xml.hps :DeveloperID, @options[:developer_id] if @options[:developer_id]
-                  xml.hps :VersionNbr, @options[:version_number] if @options[:version_number]
+                  xml.hps :DeveloperID, '002914' # xml.hps :DeveloperID, @options[:developer_id] if @options[:developer_id]
+                  xml.hps :VersionNbr, '2113' # xml.hps :VersionNbr, @options[:version_number] if @options[:version_number]
                   xml.hps :SiteTrace, @options[:site_trace] if @options[:site_trace]
                 end
                 xml.hps :Transaction do

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -5,7 +5,7 @@ module ActiveMerchant #:nodoc:
     class LitleGateway < Gateway
       SCHEMA_VERSION = '8.18'
 
-      self.test_url = 'https://www.testlitle.com/sandbox/communicator/online'
+      self.test_url = 'https://prelive.litle.com/vap/communicator/online'
       self.live_url = 'https://payments.litle.com/vap/communicator/online'
 
       self.supported_countries = ['US']

--- a/lib/active_merchant/billing/gateways/sage/sage_bankcard.rb
+++ b/lib/active_merchant/billing/gateways/sage/sage_bankcard.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class SageBankcardGateway < Gateway #:nodoc:
       include SageCore
-      self.live_url = 'https://www.sagepayments.net/cgi-bin/eftBankcard.dll?transaction'
+      self.live_url = 'https://gateway.sagepayments.net/cgi-bin/eftBankcard.dll?transaction'
       self.source = 'bankcard'
 
       # Credit cards supported by Sage


### PR DESCRIPTION
From Sage support with issues that we were seeing with response times:
"Our response time is fairly quick, unless it’s a large amount of refunds you’re POSTing at one time.  Change your endpoint to https://gateway.sagepayments.net/cgi-bin/eftBankcard.dll?transaction and see if that makes a difference."
